### PR TITLE
PKG-6683 pycosat 0.6.6 Rebuild with py313 support

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,8 @@ requirements:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
+    - patch     # [unix]
+    - m2-patch  # [win]
   host:
     - msinttypes  # [win and py2k]
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,23 +8,25 @@ package:
 source:
   url: https://github.com/conda/{{ name }}/archive/{{ version }}.tar.gz
   sha256: b0014986321e77a36d8fe24827698aae076500c817133a700608bd677b77a998
+  patches:
+    # Patch for unittest.makeSuite (removed in Python 3.13+)
+    - patches/0001-GH-100-Replace-unittest.makeSuite-with-unittest.defaultTest.patch
 
 build:
-  number: 1 # trigger
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 2
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
-    - pip
-    - setuptools
-    - wheel
   host:
     - msinttypes  # [win and py2k]
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 
@@ -46,8 +48,6 @@ about:
   home: https://github.com/conda/pycosat
   license: MIT
   license_family: MIT
-  license_file:
-    - LICENSE
   license_url: https://github.com/conda/pycosat/blob/{{ version }}/LICENSE
   summary: Bindings to picosat (a SAT solver)
   description: |
@@ -55,8 +55,7 @@ about:
     package provides efficient Python bindings to picosat on the C level, i.e.
     when importing pycosat, the picosat solver becomes part of the Python
     process itself.
-  doc_url: https://pypi.org/project/pycosat/
-  doc_source_url: https://github.com/conda/pycosat/blob/master/README.rst
+  doc_url: https://github.com/conda/pycosat/blob/master/README.rst
   dev_url: https://github.com/conda/pycosat
 
 extra:

--- a/recipe/patches/0001-GH-100-Replace-unittest.makeSuite-with-unittest.defaultTest.patch
+++ b/recipe/patches/0001-GH-100-Replace-unittest.makeSuite-with-unittest.defaultTest.patch
@@ -1,0 +1,25 @@
+From 69754b62d0fb27017f5afc39431832539573b648 Mon Sep 17 00:00:00 2001
+From: Bradley Dice <bdice@bradleydice.com>
+Date: Mon, 25 Nov 2024 10:44:40 -0600
+Subject: [PATCH] Replace unittest.makeSuite with
+ unittest.defaultTestLoader.loadTestsFromTestCase.
+
+---
+ test_pycosat.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test_pycosat.py b/test_pycosat.py
+index f1165d8..0a6969c 100644
+--- a/test_pycosat.py
++++ b/test_pycosat.py
+@@ -258,7 +258,7 @@ def run(verbosity=1, repeat=1):
+     suite = unittest.TestSuite()
+     for cls in tests:
+         for _ in range(repeat):
+-            suite.addTest(unittest.makeSuite(cls))
++            suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(cls))
+
+     runner = unittest.TextTestRunner(verbosity=verbosity)
+     return runner.run(suite)
+--
+2.45.1


### PR DESCRIPTION
pycosat 0.6.6-2 rebuild with py313 for conda

**Destination channel:** defaults}

### Links

- [PKG-6683](https://anaconda.atlassian.net/browse/PKG-6683) 
- [Upstream repository](https://github.com/conda/pycosat/tree/0.6.6)

### Explanation of Changes

- Implement conda-forge patch for module removed in Python 3.13

[PKG-6683]: https://anaconda.atlassian.net/browse/PKG-6683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ